### PR TITLE
Fix diagnostic count query and emit a daily freshness report

### DIFF
--- a/scripts/README-dbd-daily.md
+++ b/scripts/README-dbd-daily.md
@@ -37,6 +37,20 @@ tail -f scripts/logs/dbd-scrape-$(date +%Y-%m-%d).log
 ```
 A successful run ends with `Done (exit=0)` and `148 updated, 0 failed`.
 
+## Daily freshness report
+After each scrape, the wrapper runs `scripts/dbd-diagnose.py` and writes a
+report to `scripts/logs/dbd-report-$(date +%Y-%m-%d).log` (also appended to the
+scrape log). It verifies **both** pipelines from Supabase in one place:
+- **DOE whitelist** (Vercel daily cron → `scraped_at`): total agencies + latest scrape.
+- **DBD** (this scraper → `dbd_scraped_at`): populated / missing / stale counts,
+  plus any agency behind a coverage gap.
+
+Read today's report, or run it on demand:
+```bash
+cat scripts/logs/dbd-report-$(date +%Y-%m-%d).log     # today's report
+./.venv/bin/python3 scripts/dbd-diagnose.py           # run on demand (read-only)
+```
+
 ## Remove from the old Mac
 On the previous host (visarutsankham's laptop), so it doesn't double-run:
 ```bash

--- a/scripts/dbd-diagnose.py
+++ b/scripts/dbd-diagnose.py
@@ -80,8 +80,8 @@ def main() -> None:
     print("=" * 60)
     try:
         total = supabase.table("agencies").select(
-            "id", count="exact"
-        ).limit(1).execute()
+            "*", count="exact", head=True
+        ).execute()
         latest = supabase.table("agencies").select("scraped_at").order(
             "scraped_at", desc=True
         ).limit(1).execute()

--- a/scripts/run-dbd-daily.sh
+++ b/scripts/run-dbd-daily.sh
@@ -31,4 +31,14 @@ set +e
 EXIT=$?
 set -e
 echo "===== $(date '+%Y-%m-%d %H:%M:%S') Done (exit=$EXIT) =====" >> "$LOG_FILE"
+
+# Post-scrape freshness report: verifies BOTH pipelines (DOE Vercel cron and
+# DBD) from Supabase. Written to its own dated file AND appended to the log,
+# so there is a fresh report every day right after the scrape.
+REPORT_FILE="$LOG_DIR/dbd-report-$(date +%Y-%m-%d).log"
+{
+    echo "===== $(date '+%Y-%m-%d %H:%M:%S') Pipeline freshness report (host=$(hostname -s)) ====="
+    "$PYTHON" scripts/dbd-diagnose.py 2>&1
+} | tee "$REPORT_FILE" >> "$LOG_FILE"
+
 exit $EXIT


### PR DESCRIPTION
## What & why

Two things: fix a real bug in the diagnostic, and make the daily launchd job actually produce the freshness report every day.

## Changes

- **Fix count query** (`scripts/dbd-diagnose.py`) — the `agencies` table keys on `cid`, not `id`, so `select("id", count="exact")` raised a column error. Switched to `select("*", count="exact", head=True)` (count only, no rows fetched). *(This is the same fix surfaced when running the diagnostic on lighthouse-core.)*
- **Emit a daily report** (`scripts/run-dbd-daily.sh`) — after each scrape, the wrapper now runs the diagnostic and writes a dated report to `scripts/logs/dbd-report-YYYY-MM-DD.log` (also appended to the scrape log). One file per day verifying **both** pipelines from Supabase.
- **Docs** (`scripts/README-dbd-daily.md`) — document the report file and the on-demand command.

## Verification

- `bash -n scripts/run-dbd-daily.sh` passes.
- `python3 -m py_compile scripts/dbd-diagnose.py` passes.
- Reference run on lighthouse-core showed the intended output: DOE `total_agencies: 149`, `last DOE scrape: 2026-07-19T20:00:41Z`; DBD `149/149 populated, 0 missing, 0 stale`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEfBWVQLtoxfSkHsS9MwG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEfBWVQLtoxfSkHsS9MwG5)_